### PR TITLE
[Style] 리스트 페이지 수정

### DIFF
--- a/src/components/ListCard/Listcard.style.jsx
+++ b/src/components/ListCard/Listcard.style.jsx
@@ -178,8 +178,16 @@ export const Reaction = styled.div`
   border-radius: 18px;
   font: ${theme.font.H5Regular};
   height: 36px;
-  width: 70px;
+  width: 67px;
   justify-content: center;
+
+  @media (max-width: 1200px) {
+    width: 64px;
+    height: 36px;
+    font: ${theme.font.H7Regular};
+    /* font-size: 14px;
+    font: sans-serif; */
+  }
 
   @media (max-width: 600px) {
     width: 60px;

--- a/src/pages/ListPage/ListPage.style.jsx
+++ b/src/pages/ListPage/ListPage.style.jsx
@@ -59,6 +59,7 @@ export const LoadingMessage = styled.p`
 export const ButtonContainer = styled.div`
   margin-top: 80px;
   width: 280px;
+  z-index: 999;
 
   @media (max-width: 1024px) {
     bottom: 20px;


### PR DESCRIPTION
close #ISSUE_NUMBER

## 확인 사항
-![image](https://github.com/user-attachments/assets/75efe862-a237-4c34-b8aa-79f2737d0e4f)

## 작업 내용
- 리스트 페이지 버튼 z-index 부여 제일 상단에 위치하게 함
- 리스트카드 반응형 도중 이모티콘 컨테이너가 카드 우측에 겹쳐 사라지는 것 해결

