### PR TITLE
[Fix] 인기순 ListCard messageCount 순으로 재조정

### DIFF
--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -24,11 +24,11 @@ function ListPage() {
       const data = await getAllRecipients();
 
       if (Array.isArray(data)) {
-        const sortedByReaction = [...data].sort(
-          (a, b) => b.reactionCount - a.reactionCount
+        const sortedBymessage = [...data].sort(
+          (a, b) => b.messageCount - a.messageCount
         );
 
-        setPopularRecipients(sortedByReaction);
+        setPopularRecipients(sortedBymessage);
         setRecentRecipients(data);
       }
 


### PR DESCRIPTION
close #ISSUE_NUMBER

## 확인 사항
- ![image](https://github.com/user-attachments/assets/e6f9a632-371a-46c3-8410-295e9837a60d)


## 작업 내용
- 이전 이모지 많은 순서에서 메세지 많은 순서으로 변경
